### PR TITLE
Allow to define several SlurmctldHost in a list

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ More extensive example:
       SelectType: "select/cons_res"
       SelectTypeParameters: "CR_Core"
       SlurmctldHost: "slurmctl"
+      # Use a list to configure master and backups Slurmctld hosts
+      # SlurmctldHost: ['slurmctl1', 'slurmctl2']
       SlurmctldLogFile: "/var/log/slurm/slurmctld.log"
       SlurmctldPidFile: "/var/run/slurmctld.pid"
       SlurmdLogFile: "/var/log/slurm/slurmd.log"

--- a/templates/slurm.conf.j2
+++ b/templates/slurm.conf.j2
@@ -11,7 +11,13 @@ ControlMachine=localhost
 {% for key in __slurm_config_merged | sort %}
 {% set val = __slurm_config_merged[key] %}
 {% if val is not none and val != omit %}
+{% if key == 'SlurmctldHost' and val is iterable and val is not string and val is not mapping %}
+{% for slurmctldhost in val %}
+SlurmctldHost={{ slurmctldhost }}
+{% endfor %}
+{% else %}
 {{ key }}={{ 'YES' if val is sameas true else ('NO' if val is sameas false else val) }}
+{% endif %}
 {% endif %}
 {% endfor %}
 


### PR DESCRIPTION
SlurmctldHost can be defined more than once in slurm.conf to define a primary and backups Slurm controllers. If SlurmctldHost is defined as a list in `slurm_config`, then the template will add one line per list item in slurm.conf..