### PR TITLE
Make sure slurm_start_services is a boolean

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -8,7 +8,7 @@
   ansible.builtin.service:
     name: "{{ slurmdbd_service_name }}"
     state: reloaded
-  when: "slurm_start_services and ('slurmdbdservers' in group_names or 'dbd' in slurm_roles)"
+  when: "(slurm_start_services | bool) and ('slurmdbdservers' in group_names or 'dbd' in slurm_roles)"
 
 - name: Restart slurmdbd
   ansible.builtin.systemd:
@@ -17,13 +17,13 @@
     masked: no
     enabled: yes
     daemon_reload: yes
-  when: "slurm_start_services and ('slurmservers' in group_names or 'controller' in slurm_roles)"
+  when: "(slurm_start_services | bool) and ('slurmservers' in group_names or 'controller' in slurm_roles)"
 
 - name: Reload slurmctld
   ansible.builtin.service:
     name: "{{ slurmctld_service_name }}"
     state: reloaded
-  when: "slurm_start_services and ('slurmservers' in group_names or 'controller' in slurm_roles)"
+  when: "(slurm_start_services | bool) and ('slurmservers' in group_names or 'controller' in slurm_roles)"
 
 - name: Restart slurmctld
   ansible.builtin.systemd:
@@ -32,16 +32,16 @@
     masked: no
     enabled: yes
     daemon_reload: yes
-  when: "slurm_start_services and ('slurmservers' in group_names or 'controller' in slurm_roles)"
+  when: "(slurm_start_services | bool) and ('slurmservers' in group_names or 'controller' in slurm_roles)"
 
 - name: Reload slurmd
   ansible.builtin.service:
     name: "{{ slurmd_service_name }}"
     state: reloaded
-  when: "slurm_start_services and ('slurmexechosts' in group_names or 'exec' in slurm_roles)"
+  when: "(slurm_start_services | bool) and ('slurmexechosts' in group_names or 'exec' in slurm_roles)"
 
 - name: Restart slurmd
   ansible.builtin.service:
     name: "{{ slurmd_service_name }}"
     state: restarted
-  when: "slurm_start_services and ('slurmexechosts' in group_names or 'exec' in slurm_roles)"
+  when: "(slurm_start_services | bool) and ('slurmexechosts' in group_names or 'exec' in slurm_roles)"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -28,22 +28,22 @@
     name: "{{ slurmdbd_service_name }}"
     enabled: true
     state: started
-  when: "slurm_start_services and ('slurmdbdservers' in group_names or 'dbd' in slurm_roles)"
+  when: "(slurm_start_services | bool) and ('slurmdbdservers' in group_names or 'dbd' in slurm_roles)"
 
 - name: Ensure slurmctld is enabled and running
   ansible.builtin.service:
     name: "{{ slurmctld_service_name }}"
     enabled: true
     state: started
-  when: "slurm_start_services and ('slurmservers' in group_names or 'controller' in slurm_roles)"
+  when: "(slurm_start_services | bool) and ('slurmservers' in group_names or 'controller' in slurm_roles)"
 
 - name: Ensure slurmd is enabled and running
   ansible.builtin.service:
     name: "{{ slurmd_service_name }}"
     enabled: true
     state: started
-  when: "slurm_start_services and ('slurmexechosts' in group_names or 'exec' in slurm_roles)"
+  when: "(slurm_start_services | bool) and ('slurmexechosts' in group_names or 'exec' in slurm_roles)"
 
 - name: Setup cluster on slurmdb
   include_tasks: slurmdbd_cluster.yml
-  when: "slurm_start_services and ('slurmdbdservers' in group_names or 'dbd' in slurm_roles)"
+  when: "(slurm_start_services | bool) and ('slurmdbdservers' in group_names or 'dbd' in slurm_roles)"


### PR DESCRIPTION
When ansible-playbook is called with `-e slurm_start_services=false`, the variable is evaluated as a string (which is true). Apply the `| bool` filter to evaluate the variable as a boolean.