### PR TITLE
Do not setup a new SlurmDBD cluster by default

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -20,6 +20,7 @@ slurmdbd_service_name: slurmdbd
 #Cluster name for slurm config. This is required to correctly setup slurmdbd and attune it to the slurm config.
 __slurm_cluster_name: cluster
 __cluster_not_setup: true #Default value. Is modified if cluster already exists.
+slurm_setup_cluster: false
 
 slurm_start_services: true
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -46,4 +46,4 @@
 
 - name: Setup cluster on slurmdb
   include_tasks: slurmdbd_cluster.yml
-  when: "(slurm_start_services | bool) and ('slurmdbdservers' in group_names or 'dbd' in slurm_roles)"
+  when: "(slurm_setup_cluster | bool ) and (slurm_start_services | bool) and ('slurmdbdservers' in group_names or 'dbd' in slurm_roles)"


### PR DESCRIPTION
While the new feature to create a new SlurmDBD cluster could be nice in some cases, it causes some issues when one wants to reinstall a node with an existing database. IMHO, it is safer to disable this by default. One should opt-in for Ansible to create a new cluster.