### PR TITLE
Add Slurm RebootProgram support

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,39 @@ and [job_container.conf](https://slurm.schedmd.com/job_container.conf.html) may 
 `slurm_acct_gather_config`, `slurm_cgroup_config` (both of them hashes), `slurm_gres_config` (list of hashes) and
 `slurm_job_container_config` (hashes) respectively.
 
+## Node Reboot Support
+
+The role supports automatic node rebooting through Slurm's RebootProgram
+feature. To enable this:
+
+1. Set `slurm_reboot_program: true` in your playbook
+2. Configure the reboot program in `slurm_config`:
+```yaml
+slurm_config:
+  RebootProgram: "{{ slurm_config_dir }}/reboot_program"
+```
+
+The reboot program will attempt to reboot nodes using either systemd or
+traditional init systems, depending on what's available on the node.
+
+### Pre-Reboot Script
+
+You can customize the actions that run before a node reboots by setting the
+`slurm_pre_reboot_script` variable.
+
+Example configuration:
+```yaml
+slurm_reboot_program: true
+slurm_pre_reboot_script: |
+  #!/bin/bash
+  # Save node state before reboot
+  logger "Saving state for node $1"
+  # Your custom actions here
+  exit 0
+slurm_config:
+  RebootProgram: "{{ slurm_config_dir }}/reboot_program"
+```
+
 Set `slurm_upgrade` to true to upgrade the installed Slurm packages.
 
 You can use `slurm_user` (a hash) and `slurm_create_user` (a bool) to pre-create a Slurm user so that uids match.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -100,3 +100,6 @@ __slurmdbd_config_default:
   SlurmUser: "{{ __slurm_user_name }}"
   LogFile: "{{ __slurm_log_dir ~ '/slurmdbd.log' if __slurm_debian else omit }}"
 __slurmdbd_config_merged: "{{ __slurmdbd_config_default | combine(slurmdbd_config | default({})) }}"
+
+# Reboot program configuration
+slurm_reboot_program: false

--- a/tasks/_inc_extra_configs.yml
+++ b/tasks/_inc_extra_configs.yml
@@ -25,3 +25,15 @@
   notify:
     - Reload slurmctld
     - Reload slurmd
+
+- name: Install reboot program script
+  ansible.builtin.template:
+    src: reboot_program.j2
+    dest: "{{ slurm_config_dir }}/reboot_program"
+    mode: 0755
+    owner: root
+    group: root
+  when: slurm_reboot_program | bool
+  notify:
+    - Reload slurmctld
+    - Reload slurmd

--- a/templates/reboot_program.j2
+++ b/templates/reboot_program.j2
@@ -1,0 +1,24 @@
+#!/bin/bash
+##
+## This file is maintained by Ansible - ALL MODIFICATIONS WILL BE REVERTED
+##
+
+# Log the reboot attempt
+logger "Slurm attempting to reboot node $1"
+
+# Run pre-reboot script
+{{ slurm_pre_reboot_script }}
+
+# Attempt to reboot the node
+if [ -x /usr/bin/systemctl ]; then
+    # Systemd-based systems
+    /usr/bin/systemctl reboot
+elif [ -x /sbin/shutdown ]; then
+    # Traditional init systems
+    /sbin/shutdown -r now
+else
+    logger "ERROR: No reboot command found on node $1"
+    exit 1
+fi
+
+exit 0 


### PR DESCRIPTION
This commit adds support for Slurm's RebootProgram feature, allowing automatic node rebooting through Slurm. The implementation includes:

- New reboot_program.j2 template that handles node rebooting using either systemd or traditional init systems
- Configuration variable slurm_reboot_program to enable/disable the feature
- Task to install and configure the reboot program script
- Documentation in README.md explaining how to use the feature

The reboot program includes logging of reboot attempts and proper error handling. It will attempt to use systemd's reboot command first, falling back to traditional shutdown command if systemd is not available.