### PR TITLE
Add support for Slurm Topology

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,30 @@ permissions.
 Note that this role requires root access, so enable ``become`` either globally in your playbook / on the commandline or
 just for the role like [shown below](#example-playbooks).
 
+## Topology Configuration
+
+To configure Slurm topology, define the `slurm_topology_config` variable as a
+text block containing the desired content for `topology.conf`.
+
+**Important:** If you set `slurm_topology_config`, you must also set
+`TopologyPlugin` in your `slurm_config` (e.g., `TopologyPlugin:
+topology/tree`).
+
+Example:
+```yaml
+slurm_topology_config: |
+  SwitchName=s0 Nodes=tux[0-1]
+  SwitchName=s1 Nodes=tux[2-3]
+  SwitchName=s2 Switches=s[0-1]
+
+slurm_config:
+  TopologyPlugin: "topology/tree"
+  # ... other config ...
+```
+
+The `topology.conf` file will only be deployed to controller nodes (those
+running `slurmctld`).
+
 Dependencies
 ------------
 

--- a/tasks/slurmctld.yml
+++ b/tasks/slurmctld.yml
@@ -48,3 +48,20 @@
 - name: Include job_submit.lua installation tasks
   ansible.builtin.include_tasks: job_submit_lua.yml
   when: slurm_job_submit_lua is defined
+
+- name: Fail if slurm_topology_config is set but TopologyPlugin is not defined
+  ansible.builtin.fail:
+    msg: "slurm_topology_config is set, but TopologyPlugin is not defined in slurm_config. Please set TopologyPlugin (e.g., 'topology/tree')."
+  when:
+    - slurm_topology_config is defined
+    - (slurm_config.TopologyPlugin is not defined) or (slurm_config.TopologyPlugin | length == 0)
+
+- name: Deploy topology.conf if slurm_topology_config is defined
+  ansible.builtin.copy:
+    content: "{{ slurm_topology_config }}"
+    dest: "{{ slurm_config_dir }}/topology.conf"
+    owner: root
+    group: root
+    mode: 0644
+  when:
+    - slurm_topology_config is defined


### PR DESCRIPTION
Create a new variable slurm_topology_config to define the content of the topology.conf file and ensure TopologyPlugin is defined in slurm.conf when the topology must be configured.