### PR TITLE
Install topology.conf on controllers and computes

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,9 +110,6 @@ slurm_config:
   # ... other config ...
 ```
 
-The `topology.conf` file will only be deployed to controller nodes (those
-running `slurmctld`).
-
 Dependencies
 ------------
 

--- a/tasks/_inc_extra_configs.yml
+++ b/tasks/_inc_extra_configs.yml
@@ -37,3 +37,23 @@
   notify:
     - Reload slurmctld
     - Reload slurmd
+
+- name: Fail if slurm_topology_config is set but TopologyPlugin is not defined
+  ansible.builtin.fail:
+    msg: "slurm_topology_config is set, but TopologyPlugin is not defined in slurm_config. Please set TopologyPlugin (e.g., 'topology/tree')."
+  when:
+    - slurm_topology_config is defined
+    - (slurm_config.TopologyPlugin is not defined) or (slurm_config.TopologyPlugin | length == 0)
+
+- name: Deploy topology.conf if slurm_topology_config is defined
+  ansible.builtin.copy:
+    content: "{{ slurm_topology_config }}"
+    dest: "{{ slurm_config_dir }}/topology.conf"
+    owner: root
+    group: root
+    mode: 0644
+  when:
+    - slurm_topology_config is defined
+  notify:
+    - Reload slurmctld
+    - Reload slurmd

--- a/tasks/slurmctld.yml
+++ b/tasks/slurmctld.yml
@@ -48,20 +48,3 @@
 - name: Include job_submit.lua installation tasks
   ansible.builtin.include_tasks: job_submit_lua.yml
   when: slurm_job_submit_lua is defined
-
-- name: Fail if slurm_topology_config is set but TopologyPlugin is not defined
-  ansible.builtin.fail:
-    msg: "slurm_topology_config is set, but TopologyPlugin is not defined in slurm_config. Please set TopologyPlugin (e.g., 'topology/tree')."
-  when:
-    - slurm_topology_config is defined
-    - (slurm_config.TopologyPlugin is not defined) or (slurm_config.TopologyPlugin | length == 0)
-
-- name: Deploy topology.conf if slurm_topology_config is defined
-  ansible.builtin.copy:
-    content: "{{ slurm_topology_config }}"
-    dest: "{{ slurm_config_dir }}/topology.conf"
-    owner: root
-    group: root
-    mode: 0644
-  when:
-    - slurm_topology_config is defined


### PR DESCRIPTION
The file topology.conf must exist when `TopologyPlugin` is defined in slurm.conf, otherwise slurmd won't be able to start.