### PR TITLE
Remove notify from 'Install reboot program script' task

### DIFF
--- a/tasks/_inc_extra_configs.yml
+++ b/tasks/_inc_extra_configs.yml
@@ -34,9 +34,6 @@
     owner: root
     group: root
   when: slurm_reboot_program | bool
-  notify:
-    - Reload slurmctld
-    - Reload slurmd
 
 - name: Fail if slurm_topology_config is set but TopologyPlugin is not defined
   ansible.builtin.fail:


### PR DESCRIPTION
Slurm does not require a reload when modifying the reboot_program script.